### PR TITLE
Fix 'body undefined' error if installed by ELPA

### DIFF
--- a/lifted.el
+++ b/lifted.el
@@ -1,6 +1,4 @@
-;;; -*- lexical-binding: t -*-
-
-;;; lifted.el --- Functional reactive programming library for Emacs Lisp
+;;; lifted.el --- Functional reactive programming library for Emacs Lisp -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2015 Ben Yelsey
 


### PR DESCRIPTION
Problem: ELPA(emacs packaging system) removed first comment line with
lexical scope directive. This happens during installation of package
from github into local machine.

Cause: it looks like ELPA tries to transform header into some "standard"
representation.

Fix: do like emacs wiki suggests, place directive on same line with
summary.

https://www.emacswiki.org/emacs/IncrementNumber
